### PR TITLE
Use new api for Ingresses

### DIFF
--- a/helmchart/mlhub/Chart.yaml
+++ b/helmchart/mlhub/Chart.yaml
@@ -6,5 +6,5 @@ home: https://github.com/ml-tooling/ml-hub
 sources:
   - https://github.com/ml-tooling/ml-hub/helmchart
 icon: https://jupyter.org/assets/hublogo.svg
-kubeVersion: '>=1.11.0-0'
+kubeVersion: ">= 1.19.0-0"
 tillerVersion: '>=2.11.0-0'

--- a/helmchart/mlhub/templates/ingress.yaml
+++ b/helmchart/mlhub/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jupyterhub
@@ -18,9 +18,12 @@ spec:
       http:
         paths:
           - path: {{ $.Values.mlhub.baseUrl }}{{ $.Values.ingress.pathSuffix }}
+            pathType: Prefix
             backend:
-              serviceName: proxy-public
-              servicePort: 80
+              service:
+                name: proxy-public
+                port:
+                  number: 80
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] New Feature
- [x] Feature Improvment
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
Fixes #29, Tested using kubeval:
```
helm template ./mlhub --set ingress.enabled=true | kubeval -v 1.22.4 -s  https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
```
(I also tried to enable every other flags to see if it was compatible to not miss something but it seems the ingress was the only object impacted by the deprecations).

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/ml-tooling/ml-hub/blob/master/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.